### PR TITLE
ignore leading and trailing whitespace

### DIFF
--- a/world.py
+++ b/world.py
@@ -536,7 +536,7 @@ active = True
 while active == True:
 
     # Display a prompt
-    cmd = input('> ')
+    cmd = input('> ').strip()
 
     # CMD: look (object)
     if cmd.startswith('look ') and len(cmd) > 5: lookObj(cmd)


### PR DESCRIPTION
now `  look  ` will work just as well as `look`